### PR TITLE
Use miniconda to speed up Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - sudo ln -s /run/shm /dev/shm
 
 install:
+  - conda uninstall enum34
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy pandas
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,21 @@ python:
   - 2.7
 
 # Speed up Travis CI build times with Anaconda
-# http://dan-blanchard.roughdraft.io/7045057-quicker-travis-builds-that-rely-on-numpy-and-scipy-using-miniconda
+# Copied this from https://github.com/EducationalTestingService/skll/blob/87b071743ba7cf0b1063c7265005d43b172b5d91/.travis.yml
+# Which is an updated version of the pattern described in http://dan-blanchard.roughdraft.io/7045057-quicker-travis-builds-that-rely-on-numpy-and-scipy-using-miniconda
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda2/bin:$PATH
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then export PATH=/home/travis/miniconda2/bin:$PATH; else export PATH=/home/travis/miniconda3/bin:$PATH; fi
   - conda update --yes conda
-  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
-  - sudo rm -rf /dev/shm
-  - sudo ln -s /run/shm /dev/shm
 
 install:
-  - conda uninstall enum34
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy pandas
+  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.19.0 joblib prettytable python-coveralls ruamel.yaml
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes --channel defaults configparser mock; fi
+  - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then conda install --yes --channel defaults pandas seaborn; fi
+  # Have to use pip for nose-cov because its entry points are not supported by conda yet
+  - pip install nose-cov
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
   - pip install pytest
 
 script:
-  - pytest
+  - PYTHONPATH=/home/travis/build/simonw/csvs-to-sqlite/ pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 
 install:
   - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy pandas
+  - pip install click==6.7
   - pip install pytest
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,8 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy scipy beautifulsoup4 six scikit-learn==0.19.0 joblib prettytable python-coveralls ruamel.yaml
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes --channel defaults configparser mock; fi
-  - if [ ${WITH_PANDAS_AND_SEABORN} == "true" ]; then conda install --yes --channel defaults pandas seaborn; fi
-  # Have to use pip for nose-cov because its entry points are not supported by conda yet
-  - pip install nose-cov
-  - python setup.py install
+  - conda install --yes --channel defaults --channel conda-forge python=$TRAVIS_PYTHON_VERSION numpy pandas
+  - pip install pytest
 
 script:
-  - python setup.py test
+  - pytest


### PR DESCRIPTION
Using Travis CI configuration code copied from https://github.com/EducationalTestingService/skll/blob/87b071743ba7cf0b1063c7265005d43b172b5d91/.travis.yml

Which is itself an updated version of the pattern described in http://dan-blanchard.roughdraft.io/7045057-quicker-travis-builds-that-rely-on-numpy-and-scipy-using-miniconda

I had to switch to running `pytest` directly, because `python setup.py test` was still trying to install a pandas package that involved compiling everything from scratch (which is why Travis CI builds were taking around 15 minutes).