### PR TITLE
Add option for field quoting behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ They will be populated with IDs that reference the new derived tables.
 
     Options:
       -s, --separator TEXT       Field separator in input .csv
+      -q, --quoting INTEGER      Control field quoting behavior per csv.QUOTE_*
+                                   constants. Use one of QUOTE_MINIMAL (0),
+                                   QUOTE_ALL (1), QUOTE_NONNUMERIC (2) or QUOTE_NONE (3).
       --replace-tables           Replace tables if they already exist
       -c, --extract-column TEXT  One or more columns to 'extract' into a separate
                                  lookup table. If you pass a simple column name

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -26,6 +26,7 @@ import sqlite3
 )
 @click.argument('dbname', nargs=1)
 @click.option('--separator', '-s', default=',', help='Field separator in input .csv')
+@click.option('--quoting', '-q', default=0, help='Control field quoting behavior per csv.QUOTE_* constants. Use one of QUOTE_MINIMAL (0), QUOTE_ALL (1), QUOTE_NONNUMERIC (2) or QUOTE_NONE (3).')
 @click.option('--replace-tables', is_flag=True, help='Replace tables if they already exist')
 @click.option('--extract-column', '-c', multiple=True, help=(
     "One or more columns to 'extract' into a separate lookup table. "
@@ -44,7 +45,7 @@ import sqlite3
     "One or more columns to use to populate a full-text index"
 ))
 @click.version_option()
-def cli(paths, dbname, separator, replace_tables, extract_column, fts):
+def cli(paths, dbname, separator, quoting, replace_tables, extract_column, fts):
     """
     PATHS: paths to individual .csv files or to directories containing .csvs
 
@@ -70,7 +71,7 @@ def cli(paths, dbname, separator, replace_tables, extract_column, fts):
     csvs = csvs_from_paths(paths)
     for name, path in csvs.items():
         try:
-            df = load_csv(path, separator)
+            df = load_csv(path, separator, quoting)
             df.table_name = name
             dataframes.append(df)
         except LoadCsvError as e:

--- a/csvs_to_sqlite/utils.py
+++ b/csvs_to_sqlite/utils.py
@@ -10,11 +10,11 @@ class LoadCsvError(Exception):
     pass
 
 
-def load_csv(filepath, separator, encodings_to_try=('utf8', 'latin-1')):
+def load_csv(filepath, separator, quoting, encodings_to_try=('utf8', 'latin-1')):
     try:
         for encoding in encodings_to_try:
             try:
-                return pd.read_csv(filepath, separator, encoding=encoding)
+                return pd.read_csv(filepath, sep=separator, quoting=quoting, low_memory=True, encoding=encoding)
             except UnicodeDecodeError:
                 continue
             except pd.errors.ParserError as e:


### PR DESCRIPTION
I found the need to pass the ignore quoting option down to Pandas when dealing with files with unclosed quotes in fields.