### PR TITLE
Add support for loading CSVs directly from URLs

### DIFF
--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -4,6 +4,7 @@ import click
 from .utils import (
     LoadCsvError,
     LookupTable,
+    PathOrURL,
     add_index,
     apply_dates_and_datetimes,
     apply_shape,
@@ -23,7 +24,7 @@ import sqlite3
 @click.command()
 @click.argument(
     'paths',
-    type=click.Path(exists=True),
+    type=PathOrURL(exists=True),
     nargs=-1,
     required=True,
 )

--- a/csvs_to_sqlite/utils.py
+++ b/csvs_to_sqlite/utils.py
@@ -9,8 +9,8 @@ import re
 import six
 import sqlite3
 
-from urllib.parse import urlparse
-from urllib.parse import uses_relative, uses_netloc, uses_params
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import uses_relative, uses_netloc, uses_params
 
 import click
 
@@ -97,16 +97,18 @@ class PathOrURL(click.Path):
     def __init__(self, exists=False, file_okay=True, dir_okay=True,
                  writable=False, readable=True, resolve_path=False,
                  allow_dash=False, path_type=None):
-        super().__init__(exists=exists, file_okay=file_okay, dir_okay=dir_okay,
-                         writable=writable, readable=readable,
-                         resolve_path=resolve_path, allow_dash=allow_dash,
-                         path_type=path_type)
+        super(PathOrURL, self).__init__(exists=exists, file_okay=file_okay,
+                                        dir_okay=dir_okay,
+                                        writable=writable, readable=readable,
+                                        resolve_path=resolve_path,
+                                        allow_dash=allow_dash,
+                                        path_type=path_type)
 
     def convert(self, value, param, ctx):
         if _is_url(value):
             return self.coerce_path_result(value)
         else:
-            return super().convert(value, param, ctx)
+            return super(PathOrURL, self).convert(value, param, ctx)
 
 
 class LookupTable:


### PR DESCRIPTION
Closes #4 

This adds a new parameter type to support paths or URLs on the CLI.

Something like `csvs-to-sqlite https://data.stadt-zuerich.ch/dataset/wirtschaft_preise_ziw_basis2010/resource/54c7ae15-f673-41af-a7cd-b861b8c6744e/download/ziwbasis2010apr2010apr2016.csv blah.db` now works.