### PR TITLE
added --just-strings feature, to import columns as strings by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 *.egg-info
 *.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -152,5 +152,9 @@ They will be populated with IDs that reference the new derived tables.
                                    add them)
       --no-fulltext-fks            Skip adding full-text index on values extracted
                                    using --extract-column (default is to add them)
+      --just-strings               Import all columns as text strings by default
+                                   (and, if specified, still obey --shape,
+                                   --date/datetime, and --datetime-format)
+
       --version                    Show the version and exit.
       --help                       Show this message and exit.

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -116,6 +116,11 @@ import sqlite3
     is_flag=True,
     help="Skip adding full-text index on values extracted using --extract-column (default is to add them)",
 )
+@click.option(
+    "--just-strings",
+    is_flag=True,
+    help="Import all columns as text strings by default (and, if specified, still obey --shape, --date/datetime, and --datetime-format)",
+)
 @click.version_option()
 def cli(
     paths,
@@ -136,6 +141,7 @@ def cli(
     filename_column,
     no_index_fks,
     no_fulltext_fks,
+    just_strings,
 ):
     """
     PATHS: paths to individual .csv files or to directories containing .csvs
@@ -162,7 +168,7 @@ def cli(
     sql_type_overrides = None
     for name, path in csvs.items():
         try:
-            df = load_csv(path, separator, skip_errors, quoting, shape)
+            df = load_csv(path, separator, skip_errors, quoting, shape, just_strings=just_strings)
             df.table_name = table or name
             if filename_column:
                 df[filename_column] = name

--- a/csvs_to_sqlite/utils.py
+++ b/csvs_to_sqlite/utils.py
@@ -26,7 +26,9 @@ def load_csv(
     quoting,
     shape,
     encodings_to_try=("utf8", "latin-1"),
+    just_strings=False,
 ):
+    dtype = str if just_strings is True else None
     usecols = None
     if shape:
         usecols = [defn["csv_name"] for defn in parse_shape(shape)]
@@ -41,6 +43,7 @@ def load_csv(
                     low_memory=True,
                     encoding=encoding,
                     usecols=usecols,
+                    dtype=dtype,
                 )
             except UnicodeDecodeError:
                 continue


### PR DESCRIPTION
When the `--just-strings` flag is specified, then all columns will be imported and typecast as text strings. However, `--shape`, `--date`, `--datetime`, and `--datetime-format` options are still valid, and specified columns will be typecast as before. 

Inspired by this issue: [Interpret all columns as TEXT data type #42](https://github.com/simonw/csvs-to-sqlite/issues/42)