### PR TITLE
add "fixed-column" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ They will be populated with IDs that reference the new derived tables.
                                    csvcol:dbcol(TYPE),...
       --filename-column TEXT       Add a column with this name and populate with
                                    CSV file name
-      --fixed-column TEXT          For colname:value, add a column colname and
-                                   populate with value
+      --fixed-column TEXT          Populate column with a fixed value
       --no-index-fks               Skip adding index to foreign key columns
                                    created using --extract-column (default is to
                                    add them)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ They will be populated with IDs that reference the new derived tables.
                                    csvcol:dbcol(TYPE),...
       --filename-column TEXT       Add a column with this name and populate with
                                    CSV file name
+      --fixed-column TEXT          For colname:value, add a column colname and
+                                   populate with value
       --no-index-fks               Skip adding index to foreign key columns
                                    created using --extract-column (default is to
                                    add them)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ They will be populated with IDs that reference the new derived tables.
                                    csvcol:dbcol(TYPE),...
       --filename-column TEXT       Add a column with this name and populate with
                                    CSV file name
-      --fixed-column TEXT          Populate column with a fixed value
+  --fixed-column <TEXT TEXT>...    Populate column with a fixed string
+  --fixed-column-int <TEXT INTEGER>...
+                                   Populate column with a fixed integer
+  --fixed-column-float <TEXT FLOAT>...
+                                   Populate column with a fixed float
       --no-index-fks               Skip adding index to foreign key columns
                                    created using --extract-column (default is to
                                    add them)

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -167,6 +167,8 @@ def cli(
         raise click.BadParameter("dbname must not end with .csv")
     if "." not in dbname:
         dbname += ".db"
+    if fixed_columns:
+        fixed_columns = [_.split(":") for _ in fixed_columns]
 
     db_existed = os.path.exists(dbname)
 
@@ -186,6 +188,8 @@ def cli(
                 if shape:
                     shape += ",{}".format(filename_column)
             if fixed_columns:
+                print(fixed_columns)
+                print(len(fixed_columns))
                 for colname, value in fixed_columns:
                     df[colname] = value
                     if shape:

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -109,7 +109,23 @@ import sqlite3
     "--fixed-column",
     type=(str, str),
     multiple=True,
-    help="Populate column with a fixed value",
+    help="Populate column with a fixed string",
+    default=None,
+)
+@click.option(
+    "fixed_columns_int",
+    "--fixed-column-int",
+    type=(str, int),
+    multiple=True,
+    help="Populate column with a fixed integer",
+    default=None,
+)
+@click.option(
+    "fixed_columns_float",
+    "--fixed-column-float",
+    type=(str, float),
+    multiple=True,
+    help="Populate column with a fixed float",
     default=None,
 )
 @click.option(
@@ -148,6 +164,8 @@ def cli(
     shape,
     filename_column,
     fixed_columns,
+    fixed_columns_int,
+    fixed_columns_float,
     no_index_fks,
     no_fulltext_fks,
     just_strings,
@@ -188,6 +206,16 @@ def cli(
             if fixed_columns:
                 for colname, value in fixed_columns:
                     df[colname] = value
+                    if shape:
+                        shape += ",{}".format(colname)
+            if fixed_columns_int:
+                for colname, value in fixed_columns_int:
+                    df[colname] = int(value)
+                    if shape:
+                        shape += ",{}".format(colname)
+            if fixed_columns_float:
+                for colname, value in fixed_columns_float:
+                    df[colname] = float(value)
                     if shape:
                         shape += ",{}".format(colname)
             sql_type_overrides = apply_shape(df, shape)

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -105,9 +105,11 @@ import sqlite3
     default=None,
 )
 @click.option(
+    "fixed_columns",
     "--fixed-column",
+    type=(str, str),
     multiple=True,
-    help="For colname:value, add a column colname and populate with value",
+    help="Populate column with a fixed value",
     default=None,
 )
 @click.option(
@@ -145,7 +147,7 @@ def cli(
     index,
     shape,
     filename_column,
-    fixed_column,
+    fixed_columns,
     no_index_fks,
     no_fulltext_fks,
     just_strings,
@@ -158,8 +160,6 @@ def cli(
     # make plural for more readable code:
     extract_columns = extract_column
     del extract_column
-    fixed_columns = fixed_column
-    del fixed_column
 
     if extract_columns:
         click.echo("extract_columns={}".format(extract_columns))
@@ -167,8 +167,6 @@ def cli(
         raise click.BadParameter("dbname must not end with .csv")
     if "." not in dbname:
         dbname += ".db"
-    if fixed_columns:
-        fixed_columns = [_.split(":") for _ in fixed_columns]
 
     db_existed = os.path.exists(dbname)
 

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -210,12 +210,12 @@ def cli(
                         shape += ",{}".format(colname)
             if fixed_columns_int:
                 for colname, value in fixed_columns_int:
-                    df[colname] = int(value)
+                    df[colname] = value
                     if shape:
                         shape += ",{}".format(colname)
             if fixed_columns_float:
                 for colname, value in fixed_columns_float:
-                    df[colname] = float(value)
+                    df[colname] = value
                     if shape:
                         shape += ",{}".format(colname)
             sql_type_overrides = apply_shape(df, shape)

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -188,8 +188,6 @@ def cli(
                 if shape:
                     shape += ",{}".format(filename_column)
             if fixed_columns:
-                print(fixed_columns)
-                print(len(fixed_columns))
                 for colname, value in fixed_columns:
                     df[colname] = value
                     if shape:

--- a/csvs_to_sqlite/cli.py
+++ b/csvs_to_sqlite/cli.py
@@ -105,6 +105,12 @@ import sqlite3
     default=None,
 )
 @click.option(
+    "--fixed-column",
+    multiple=True,
+    help="For colname:value, add a column colname and populate with value",
+    default=None,
+)
+@click.option(
     "--no-index-fks",
     "no_index_fks",
     is_flag=True,
@@ -139,6 +145,7 @@ def cli(
     index,
     shape,
     filename_column,
+    fixed_column,
     no_index_fks,
     no_fulltext_fks,
     just_strings,
@@ -151,6 +158,8 @@ def cli(
     # make plural for more readable code:
     extract_columns = extract_column
     del extract_column
+    fixed_columns = fixed_column
+    del fixed_column
 
     if extract_columns:
         click.echo("extract_columns={}".format(extract_columns))
@@ -176,6 +185,11 @@ def cli(
                 df[filename_column] = name
                 if shape:
                     shape += ",{}".format(filename_column)
+            if fixed_columns:
+                for colname, value in fixed_columns:
+                    df[colname] = value
+                    if shape:
+                        shape += ",{}".format(colname)
             sql_type_overrides = apply_shape(df, shape)
             apply_dates_and_datetimes(df, date, datetime, datetime_format)
             dataframes.append(df)

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -367,9 +367,9 @@ def test_fixed_column():
                 "test.csv",
                 "test.db",
                 "--fixed-column",
-                "test1:hello",
+                "col1:foo",
                 "--fixed-column",
-                "test2:world"
+                "col2:bar"
             ]
         )
         assert result.exit_code == 0
@@ -383,17 +383,17 @@ def test_fixed_column():
             (4, "party", "TEXT", 0, None, 0),
             (5, "candidate", "TEXT", 0, None, 0),
             (6, "votes", "INTEGER", 0, None, 0),
-            (7, "test1", "TEXT", 0, None, 0),
-            (8, "test2", "TEXT", 0, None, 0),
+            (7, "col1", "TEXT", 0, None, 0),
+            (8, "col2", "TEXT", 0, None, 0),
         ] == list(conn.execute("PRAGMA table_info(test)"))
         rows = conn.execute("select * from test").fetchall()
         assert [
-            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "hello", "world"),
-            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "hello", "world"),
-            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "hello", "world"),
-            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "hello", "world"),
-            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "hello", "world"),
-            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "hello", "world"),
+            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "foo", "bar"),
+            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "foo", "bar"),
+            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "foo", "bar"),
+            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "foo", "bar"),
+            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "foo", "bar"),
+            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "foo", "bar"),
         ] == rows
 
 
@@ -407,17 +407,17 @@ def test_fixed_column_with_shape():
                 "test.csv",
                 "test.db",
                 "--fixed-column",
-                "test1:hello",
+                "col1:foo",
                 "--fixed-column",
-                "test2:world",
+                "col2:bar",
                 "--shape",
                 "county:Cty,votes:Vts",
             ],
         )
         assert result.exit_code == 0
         conn = sqlite3.connect("test.db")
-        assert [("Yolo", 41, "test", "hello", "world")] == conn.execute(
-            "select Cty, Vts, source from test limit 1"
+        assert [("Yolo", 41, "foo", "bar")] == conn.execute(
+            "select Cty, Vts, col1, col2 from test limit 1"
         ).fetchall()
 
 

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -369,11 +369,14 @@ def test_fixed_column():
                 "--fixed-column",
                 "col1",
                 "foo",
-                "--fixed-column-int",
+                "--fixed-column",
                 "col2",
+                "bar",
+                "--fixed-column-int",
+                "col3",
                 "1",
                 "--fixed-column-float",
-                "col3",
+                "col4",
                 "1.1"
             ]
         )
@@ -389,17 +392,18 @@ def test_fixed_column():
             (5, "candidate", "TEXT", 0, None, 0),
             (6, "votes", "INTEGER", 0, None, 0),
             (7, "col1", "TEXT", 0, None, 0),
-            (8, "col2", "INTEGER", 0, None, 0),
-            (9, "col3", "REAL", 0, None, 0),
+            (8, "col2", "TEXT", 0, None, 0),
+            (9, "col3", "INTEGER", 0, None, 0),
+            (10, "col3", "REAL", 0, None, 0),
         ] == list(conn.execute("PRAGMA table_info(test)"))
         rows = conn.execute("select * from test").fetchall()
         assert [
-            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "foo", 1, 1.1),
-            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "foo", 1, 1.1),
-            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "foo", 1, 1.1),
-            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "foo", 1, 1.1),
-            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "foo", 1, 1.1),
-            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "foo", 1, 1.1),
+            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "foo", "bar", 1, 1.1),
+            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "foo", "bar", 1, 1.1),
+            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "foo", "bar", 1, 1.1),
+            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "foo", "bar", 1, 1.1),
+            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "foo", "bar", 1, 1.1),
+            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "foo", "bar", 1, 1.1),
         ] == rows
 
 

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -369,9 +369,12 @@ def test_fixed_column():
                 "--fixed-column",
                 "col1",
                 "foo",
-                "--fixed-column",
+                "--fixed-column-int",
                 "col2",
-                "bar"
+                "1",
+                "--fixed-column-float",
+                "col3",
+                "1.1"
             ]
         )
         assert result.exit_code == 0
@@ -386,16 +389,17 @@ def test_fixed_column():
             (5, "candidate", "TEXT", 0, None, 0),
             (6, "votes", "INTEGER", 0, None, 0),
             (7, "col1", "TEXT", 0, None, 0),
-            (8, "col2", "TEXT", 0, None, 0),
+            (8, "col2", "INTEGER", 0, None, 0),
+            (9, "col3", "REAL", 0, None, 0),
         ] == list(conn.execute("PRAGMA table_info(test)"))
         rows = conn.execute("select * from test").fetchall()
         assert [
-            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "foo", "bar"),
-            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "foo", "bar"),
-            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "foo", "bar"),
-            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "foo", "bar"),
-            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "foo", "bar"),
-            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "foo", "bar"),
+            ("Yolo", 100001, "President", None, "LIB", "Gary Johnson", 41, "foo", 1, 1.1),
+            ("Yolo", 100001, "President", None, "PAF", "Gloria Estela La Riva", 8, "foo", 1, 1.1),
+            ("Yolo", 100001, "Proposition 51", None, None, "No", 398, "foo", 1, 1.1),
+            ("Yolo", 100001, "Proposition 51", None, None, "Yes", 460, "foo", 1, 1.1),
+            ("Yolo", 100001, "State Assembly", 7, "DEM", "Kevin McCarty", 572, "foo", 1, 1.1),
+            ("Yolo", 100001, "State Assembly", 7, "REP", "Ryan K. Brown", 291, "foo", 1, 1.1),
         ] == rows
 
 

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -394,7 +394,7 @@ def test_fixed_column():
             (7, "col1", "TEXT", 0, None, 0),
             (8, "col2", "TEXT", 0, None, 0),
             (9, "col3", "INTEGER", 0, None, 0),
-            (10, "col3", "REAL", 0, None, 0),
+            (10, "col4", "REAL", 0, None, 0),
         ] == list(conn.execute("PRAGMA table_info(test)"))
         rows = conn.execute("select * from test").fetchall()
         assert [

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -367,9 +367,11 @@ def test_fixed_column():
                 "test.csv",
                 "test.db",
                 "--fixed-column",
-                "col1:foo",
+                "col1",
+                "foo",
                 "--fixed-column",
-                "col2:bar"
+                "col2",
+                "bar"
             ]
         )
         assert result.exit_code == 0
@@ -407,9 +409,11 @@ def test_fixed_column_with_shape():
                 "test.csv",
                 "test.db",
                 "--fixed-column",
-                "col1:foo",
+                "col1",
+                "foo",
                 "--fixed-column",
-                "col2:bar",
+                "col2",
+                "bar",
                 "--shape",
                 "county:Cty,votes:Vts",
             ],

--- a/tests/test_csvs_to_sqlite.py
+++ b/tests/test_csvs_to_sqlite.py
@@ -358,6 +358,9 @@ def test_filename_column_with_shape():
 
 
 def test_fixed_column():
+    """
+    Tests that all three fixed_column options are handled correctly.
+    """
     runner = CliRunner()
     with runner.isolated_filesystem():
         open("test.csv", "w").write(CSV)
@@ -408,6 +411,9 @@ def test_fixed_column():
 
 
 def test_fixed_column_with_shape():
+    """
+    Test that fixed_column works with shape.
+    """
     runner = CliRunner()
     with runner.isolated_filesystem():
         open("test.csv", "w").write(CSV)


### PR DESCRIPTION
For colname:value, add a column colname and populate with value.

The use case here is that I have a snakemake workflow that produces a lot of csv files with a structure like:
`samples/<sample_id>/<condition_name>/this.csv`
I want to import them all into the same table, where `sample_id` and `condition_name` are columns.  I tried to match how `--filename_column` works, but allow for multiple new columns to be added.

I haven't yet added any tests, but if you think this option would be a useful addition, I will add some tests to cover the basic use case and the combination with shape.